### PR TITLE
BUG: Renaming the file name and changing the schedule to 5 minute

### DIFF
--- a/.github/workflows/rabbit_consumer_prototype.yaml
+++ b/.github/workflows/rabbit_consumer_prototype.yaml
@@ -1,8 +1,8 @@
-name: Rabbit Consumer
+name: Rabbit Consumer Protoype
 
 on:
   schedule: 
-      - cron: "1 * * * *" # Every minute
+      - cron: "5 * * * *" # Every 5 minutes
 
 jobs:
   test_and_lint:


### PR DESCRIPTION
Because the cron job wasn't running, docs said rate limit was 5min and changed the name to prototype to defferentiate the file names.