### PR TITLE
Error: exit code 127, doubled the workspace variable.

### DIFF
--- a/.github/workflows/rabbit_consumer_prototype.yaml
+++ b/.github/workflows/rabbit_consumer_prototype.yaml
@@ -14,11 +14,12 @@ jobs:
       - uses: actions/checkout@v4
 
 
-      #- name: Increment Version
-        #run: /home/runner/work/SCD-OpenStack-Utils/SCD-OpenStack-Utils/.github/workflows/bin/version_increment.sh
 
       - name: Increment Version
-        run: bash ${{ github.workspace }}/.github/workflows/bin/version_increment.sh
+        run: /home/runner/work/SCD-OpenStack-Utils/.github/workflows/bin/version_increment.sh
+
+      #- name: Increment Version
+        #run: bash ${{ github.workspace }}/.github/workflows/bin/version_increment.sh
 
       - name: Commit Changes
         uses: EndBug/add-and-commit@v9


### PR DESCRIPTION
Testing the new absolute path /home/runner/work/SCD-OpenStack-Utils/.github/workflows/bin/