### PR TITLE
Bug: version.txt file is not updating.

### DIFF
--- a/.github/workflows/bin/version_increment.sh
+++ b/.github/workflows/bin/version_increment.sh
@@ -25,3 +25,5 @@ echo $newversion
 
 #overwrites the version.txt file with new new version
 printf "$newversion" > /home/runner/work/SCD-OpenStack-Utils/SCD-OpenStack-Utils/OpenStack-Rabbit-Consumer/version.txt
+
+cat /home/runner/work/SCD-OpenStack-Utils/SCD-OpenStack-Utils/OpenStack-Rabbit-Consumer/version.txt

--- a/.github/workflows/rabbit_consumer_prototype.yaml
+++ b/.github/workflows/rabbit_consumer_prototype.yaml
@@ -28,4 +28,4 @@ jobs:
       - name: Commit Changes
         uses: EndBug/add-and-commit@v9
         with:
-          add: version.txt
+          add: /home/runner/work/SCD-OpenStack-Utils/SCD-OpenStack-Utils/OpenStack-Rabbit-Consumer/version.txt


### PR DESCRIPTION
Printing out contents of version.txt file after the script runs and added an absolute file path to the commit-and-add flag.